### PR TITLE
Prof: adds template for conventions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -63,3 +63,4 @@ typings/
 # build outputs
 dist/
 .awcache
+.idea

--- a/.gitmessage
+++ b/.gitmessage
@@ -1,0 +1,27 @@
+<story-type>(short-title): <description>
+
+<bullet-listed-commit-body>
+
+[<status>]
+
+#
+#
+# <story-type> can be either of:
+#  - feat for Features
+#  - chore for Chores
+#  - bug for bug fixes
+#
+#  <status> can be either of
+#  - Completes for completed features and bugs
+#  - Maintains for completed features and bugs
+#  - Started for tasks that have just been started
+#
+# Example:
+#
+# feat(auth): user sign up:
+#
+# - adds sign up route to the app
+# - installs pyjwt package
+#
+#
+# [Started]

--- a/pull_request_template.md
+++ b/pull_request_template.md
@@ -1,0 +1,7 @@
+#### What does this PR 
+#### Any background context?
+#### Manual Testing Steps
+#### Screenshots:
+#### Relevant Trello Tickets
+- [Ticket 1](http://some.com)
+


### PR DESCRIPTION
#### What does this PR 
- adds a .gitmessage that contains commit conventions
- adds a pull_request_template that contains pull request template


#### Any background context?
- None

#### Manual Testing Steps
- Run `git config --local commit.template .gitmessage` to activate commit template. Running successive `git commit` commands should show you the template
- When you raise your next PR you should see the template

#### Relevant Trello Tickets
- [Make conventions easier to follow](https://trello.com/c/AefXEyim/41-make-the-following-conventions-for-tasks-a-little-easier)
