### PR TITLE
Prof: Adds settings layout to the app

### DIFF
--- a/src/components/layouts/SettingsPageLayout/index.stories.tsx
+++ b/src/components/layouts/SettingsPageLayout/index.stories.tsx
@@ -1,0 +1,35 @@
+import * as React from 'react';
+import SettingsPageLayout from '.';
+
+export default {
+  component: SettingsPageLayout,
+  title: 'components/layouts/SettingsPageLayout',
+};
+
+export const emptyStructure = () => {
+  return <SettingsPageLayout />;
+};
+
+export const layoutWithContnent = () => {
+  const applianceCategories = [
+    ['Generators', 'Lorem ipsum dolor sit amet, consectetur adipiscing elit...'],
+    ['Pumps', 'Lorem ipsum dolor sit amet, consectetur adipiscing elit...'],
+    ['Lifts', 'Lorem ipsum dolor sit amet, consectetur adipiscing elit...'],
+    ['Motor', 'Lorem ipsum dolor sit amet, consectetur adipiscing elit...'],
+    ['Wind Mill', 'Lorem ipsum dolor sit amet, consectetur adipiscing elit...'],
+    ['Regulator', 'Lorem ipsum dolor sit amet, consectetur adipiscing elit...'],
+  ];
+
+  const parameters = [
+    ['Voltage', 'Lorem ipsum dolor sit amet, consectetur adipiscing elit...'],
+    ['Current', 'Lorem ipsum dolor sit amet, consectetur adipiscing elit...'],
+    ['Ampere', 'Lorem ipsum dolor sit amet, consectetur adipiscing elit...'],
+  ];
+
+  const units = [
+    ['J', 'Joules'],
+    ['A', 'Current'],
+  ];
+
+  return <SettingsPageLayout units={units} applianceCategories={applianceCategories} parameters={parameters} />;
+};

--- a/src/components/layouts/SettingsPageLayout/index.tsx
+++ b/src/components/layouts/SettingsPageLayout/index.tsx
@@ -1,0 +1,136 @@
+import * as React from 'react';
+import styled from '@emotion/styled';
+import Tab, { TabItem } from 'components/ui/Tab';
+import Input, { InputType } from '../../ui/Input';
+import { action } from '@storybook/addon-actions';
+import Button, { ButtonType } from 'components/ui/Button';
+import Table, { TableCard, TableItem } from 'components/ui/Table';
+const { useState } = React;
+
+interface ContentProps {
+  data: string[][];
+  colFlexMap: object;
+}
+
+interface SettingsLayoutProps {
+  units?: string[][];
+  parameters?: string[][];
+  applianceCategories?: string[][];
+  children?: React.ReactNode;
+}
+function Content(props: ContentProps) {
+  const { data, colFlexMap } = props;
+  if (data.length === 0) {
+    return (
+      <Table>
+        <TableCard>
+          <TableItem textAlign="center">No Results was found</TableItem>
+        </TableCard>
+      </Table>
+    );
+  }
+  return (
+    <Table>
+      {data.map((row, index) => (
+        <TableCard key={index}>
+          {row.map((value, index) => (
+            <TableItem key={index} flexValue={colFlexMap[index]}>
+              {value}
+            </TableItem>
+          ))}
+        </TableCard>
+      ))}
+    </Table>
+  );
+}
+export default function SettingsPageLayout(props: SettingsLayoutProps) {
+  const { units = [], parameters = [], applianceCategories = [] } = props;
+  const [currentWindow, setWindow] = React.useState(0);
+  function handleTabChange(tabNumber: number) {
+    setWindow(tabNumber);
+    console.log(currentWindow);
+  }
+
+  const colMapper = {
+    0: 2,
+    1: 10,
+  };
+  return (
+    <SettingsPageLayout.Wrapper>
+      <h1>Settings</h1>
+      <SettingsPageLayout.ControlsWrapper>
+        <SettingsPageLayout.Tabs>
+          <Tab onTabChange={handleTabChange}>
+            {({ setTab, tab }): React.ReactNode => (
+              <>
+                <TabItem itemValue={0} currentValue={tab} setTab={setTab}>
+                  Appliance Category
+                </TabItem>
+                <TabItem itemValue={1} currentValue={tab} setTab={setTab}>
+                  Parameters
+                </TabItem>
+                <TabItem itemValue={2} currentValue={tab} setTab={setTab}>
+                  Units
+                </TabItem>
+              </>
+            )}
+          </Tab>
+        </SettingsPageLayout.Tabs>
+
+        <SettingsPageLayout.ControlsWrapper>
+          <Input
+            iconLabel="md-search"
+            type="text"
+            name="search"
+            title=""
+            value=""
+            errorFeedback={[]}
+            handleChange={action('Clicked')}
+            handleBlur={action('Blur Handler!!')}
+            placeholder="Search"
+          />
+        </SettingsPageLayout.ControlsWrapper>
+        <SettingsPageLayout.NewItem>
+          <Button type="button" isLoading={false} disabled={false} handleClick={action('clicked')}>
+            Create New
+          </Button>
+        </SettingsPageLayout.NewItem>
+      </SettingsPageLayout.ControlsWrapper>
+      <div>
+        {currentWindow == 0 ? (
+          <Content data={applianceCategories} colFlexMap={colMapper} />
+        ) : currentWindow == 1 ? (
+          <Content data={parameters} colFlexMap={colMapper} />
+        ) : (
+          <Content data={units} colFlexMap={colMapper} />
+        )}
+      </div>
+    </SettingsPageLayout.Wrapper>
+  );
+}
+
+SettingsPageLayout.ControlsWrapper = styled.div`
+  display: flex;
+  align-items: center;
+  > div {
+    padding: 0 2%;
+  }
+`;
+
+SettingsPageLayout.NewItem = styled.div`
+  flex: 2;
+`;
+SettingsPageLayout.Tabs = styled.div`
+  flex: 10;
+  padding-left: 0;
+`;
+
+SettingsPageLayout.Wrapper = styled.div`
+  padding: 0 3%;
+  h1 {
+    font-family: Fira Sans;
+    font-style: normal;
+    font-size: 24px;
+    font-weight: 500;
+  }
+`;

--- a/src/components/pages/Authentication/index.tsx
+++ b/src/components/pages/Authentication/index.tsx
@@ -26,7 +26,7 @@ function Authentication({ isLoading }: AuthenticationFormProps): React.ReactElem
 
   if (String(isAuthenticated) === 'true') return <Redirect to="/dashboard" />;
 
-  function handleTabChange(tabNumber: number): (event: React.SyntheticEvent) => void {
+  function forgotLinkClicked(tabNumber: number): (event: React.SyntheticEvent) => void {
     return (event: React.SyntheticEvent): void => {
       event.preventDefault();
       setDisplay(tabNumber);
@@ -34,14 +34,14 @@ function Authentication({ isLoading }: AuthenticationFormProps): React.ReactElem
   }
 
   return (
-    <AuthenticationLayout showTerms={display == 1}>
-      <AuthenticationFormWrapper display={display} handleTabChange={handleTabChange} showHeader={true}>
-        {display == 2 ? (
+    <AuthenticationLayout showTerms={display === 1}>
+      <AuthenticationFormWrapper handleTabChange={setDisplay} showHeader={true}>
+        {display === 2 ? (
           <ForgotPassword isLoading={isLoading} />
-        ) : display == 1 ? (
+        ) : display === 1 ? (
           <SignUp isLoading={isLoading} />
         ) : (
-          <Login isLoading={isLoading} forgotLinkClicked={handleTabChange(2)} />
+          <Login isLoading={isLoading} forgotLinkClicked={forgotLinkClicked(2)} />
         )}
       </AuthenticationFormWrapper>
     </AuthenticationLayout>

--- a/src/components/ui/AuthenticationFormWrapper/index.stories.tsx
+++ b/src/components/ui/AuthenticationFormWrapper/index.stories.tsx
@@ -8,7 +8,5 @@ export default {
 };
 
 export const authenticationFormWrapper = (): React.ReactElement<AuthenticationFormWrapperProps> => (
-  <AuthenticationFormWrapper display={number('display', 0)} showHeader={boolean('showHeader', false)}>
-    {''}
-  </AuthenticationFormWrapper>
+  <AuthenticationFormWrapper showHeader={boolean('showHeader', false)}>{''}</AuthenticationFormWrapper>
 );

--- a/src/components/ui/AuthenticationFormWrapper/index.tsx
+++ b/src/components/ui/AuthenticationFormWrapper/index.tsx
@@ -2,39 +2,31 @@ import * as React from 'react';
 import styled from '@emotion/styled';
 import { connect } from 'react-redux';
 import Tab, { TabItem } from 'components/ui/Tab';
-import __spacing from 'settings/__spacing';
-import { fontSizes } from 'settings/__fonts';
-import { GRAY, BLACK, GAINS_BORO } from 'settings/__color';
 
 export interface AuthenticationFormWrapperProps {
-  display?: number;
   showHeader?: boolean;
   children: React.ReactNode;
-  handleTabChange?: (tabNumber: number) => React.EventHandler<React.SyntheticEvent>;
+  handleTabChange?: Function;
 }
 
 export function AuthenticationFormWrapper(
   props: AuthenticationFormWrapperProps,
 ): React.ReactElement<AuthenticationFormWrapperProps> {
-  const {
-    display,
-    showHeader = true,
-    children,
-    handleTabChange = () => {
-      return (() => null) as React.EventHandler<React.SyntheticEvent>;
-    },
-  } = props;
-
+  const { showHeader = true, children, handleTabChange } = props;
   return (
     <AuthenticationFormWrapper.Wrapper>
       {showHeader && (
-        <Tab>
-          <TabItem selected={display === 1} onClick={handleTabChange(1)}>
-            Sign Up
-          </TabItem>
-          <TabItem selected={display === 0} onClick={handleTabChange(0)}>
-            Login
-          </TabItem>
+        <Tab onTabChange={handleTabChange}>
+          {({ tab, setTab }) => (
+            <>
+              <TabItem setTab={setTab} itemValue={1} currentValue={tab}>
+                Sign Up
+              </TabItem>
+              <TabItem setTab={setTab} itemValue={0} currentValue={tab}>
+                Login
+              </TabItem>
+            </>
+          )}
         </Tab>
       )}
       <AuthenticationFormWrapper.Content>{children}</AuthenticationFormWrapper.Content>

--- a/src/components/ui/Input/index.tsx
+++ b/src/components/ui/Input/index.tsx
@@ -18,6 +18,7 @@ export interface InputProps {
   handleChange: (event: React.ChangeEvent<HTMLInputElement>) => void;
   handleBlur?: (event: React.FocusEvent<HTMLInputElement>) => void;
   iconLabel?: string;
+  placeholder?: string;
 }
 
 export default function Input(props: InputProps): React.ReactElement<InputProps> {
@@ -31,17 +32,18 @@ export default function Input(props: InputProps): React.ReactElement<InputProps>
     value,
     errorFeedback = [],
     iconLabel = '',
+    placeholder = '',
   } = props;
   return (
     <Input.Container>
       <label>{title}</label>
-      <Input.Wrapper>
+      <Input.IconAndInputGroup>
         {iconLabel && (
           <Input.IconLabel>
             <Icon iconType={iconLabel} size="NORMAL" />
           </Input.IconLabel>
         )}
-        <div>
+        <Input.Wrapper>
           <input
             autoComplete={autoComplete}
             value={value}
@@ -49,15 +51,16 @@ export default function Input(props: InputProps): React.ReactElement<InputProps>
             type={type}
             onChange={handleChange}
             onBlur={handleBlur}
+            placeholder={placeholder}
           />
-        </div>
-      </Input.Wrapper>
+        </Input.Wrapper>
+      </Input.IconAndInputGroup>
       <InputErrors errorFeedback={errorFeedback} />
     </Input.Container>
   );
 }
 
-Input.Wrapper = styled.div`
+Input.IconAndInputGroup = styled.div`
   border: 1px solid ${GAINS_BORO};
   border-radius: 3px;
   margin: ${__spacing.xSmall} 0;
@@ -70,14 +73,13 @@ Input.Wrapper = styled.div`
     border: none;
     outline: none;
   }
-
-  > div {
-    width: 100%;
-  }
 `;
-
+Input.Wrapper = styled.div`
+  width: 100%;
+`;
 Input.IconLabel = styled.div`
   padding-left: ${__spacing.small};
+  width: auto;
 `;
 
 Input.Container = styled.div`

--- a/src/components/ui/SuspenseLoader/index.tsx
+++ b/src/components/ui/SuspenseLoader/index.tsx
@@ -18,11 +18,13 @@ SuspenseLoader.Wrapper = styled.div`
   width: 100%;
   height: 100vh;
   position: relative;
+  display: flex;
+  justify-content: center;
+  align-items: center;
   .circle {
     position: absolute;
-    top: 50%;
     left: 50%;
-    transform: traslate(-50%, -50%);
+    transform: translate(-50%, -50%);
     display: flex;
     width: 60px;
     height: 60px;

--- a/src/components/ui/Tab/index.stories.tsx
+++ b/src/components/ui/Tab/index.stories.tsx
@@ -1,45 +1,66 @@
 import React from 'react';
 import { boolean } from '@storybook/addon-knobs';
 import { action } from '@storybook/addon-actions';
-import Tab, { TabItem } from '.';
+import Tab, { TabItem, TabProps } from '.';
 import Icon from 'components/ui/Icon';
 export default {
   component: Tab,
   title: 'components/ui/Tab',
 };
 
-export const orgPortalTabs = () => (
-  <Tab>
-    <TabItem onClick={action('Tab Clicked')} selected={boolean('Appliance Category', true)}>
-      Appliance Category
-    </TabItem>
-    <TabItem onClick={action('Tab Clicked')} selected={boolean('Parameters', false)}>
-      Parameters
-    </TabItem>
-    <TabItem onClick={action('Tab Clicked')} selected={boolean('Units', false)}>
-      Units
-    </TabItem>
-  </Tab>
-);
+function onTabChange(value) {
+  action('Tab changed to ' + value)();
+}
+export const orgPortalTabs = () => {
+  return (
+    <Tab onTabChange={onTabChange}>
+      {({ setTab, tab }) => (
+        <>
+          <TabItem setTab={setTab} itemValue={0} currentValue={tab}>
+            Appliance Category
+          </TabItem>
+          <TabItem setTab={setTab} itemValue={1} currentValue={tab}>
+            Parameters
+          </TabItem>
+          <TabItem setTab={setTab} itemValue={2} currentValue={tab}>
+            Units
+          </TabItem>
+        </>
+      )}
+    </Tab>
+  );
+};
 
-export const authPage = () => (
-  <Tab>
-    <TabItem onClick={action('Tab Clicked')} selected={boolean('Sign Up', true)}>
-      Sign Up
-    </TabItem>
-    <TabItem onClick={action('Tab Clicked')} selected={boolean('Login', false)}>
-      Login
-    </TabItem>
-  </Tab>
-);
+export const authPage = () => {
+  return (
+    <Tab onTabChange={onTabChange}>
+      {({ setTab, tab }) => (
+        <>
+          <TabItem setTab={setTab} itemValue={0} currentValue={tab}>
+            Sign Up
+          </TabItem>
+          <TabItem setTab={setTab} itemValue={1} currentValue={tab}>
+            Login
+          </TabItem>
+        </>
+      )}
+    </Tab>
+  );
+};
 
-export const IconsInTabs = () => (
-  <Tab>
-    <TabItem onClick={action('Tab Clicked')} selected={boolean('Likes', true)}>
-      <Icon iconType="md-thumbs-up" size="LARGE" color="SUCCESS" />
-    </TabItem>
-    <TabItem onClick={action('Tab Clicked')} selected={boolean('Rating', false)}>
-      <Icon iconType="md-star" size="LARGE" color="INFO" />
-    </TabItem>
-  </Tab>
-);
+export const IconsInTabs = () => {
+  return (
+    <Tab onTabChange={onTabChange}>
+      {({ setTab, tab }) => (
+        <>
+          <TabItem setTab={setTab} itemValue={0} currentValue={tab}>
+            <Icon iconType="md-thumbs-up" size="LARGE" color="SUCCESS" />
+          </TabItem>
+          <TabItem setTab={setTab} itemValue={1} currentValue={tab}>
+            <Icon iconType="md-star" size="LARGE" color="INFO" />
+          </TabItem>
+        </>
+      )}
+    </Tab>
+  );
+};

--- a/src/components/ui/Tab/index.tsx
+++ b/src/components/ui/Tab/index.tsx
@@ -2,20 +2,28 @@ import * as React from 'react';
 import styled from '@emotion/styled';
 import { GAINS_BORO } from '../../../settings/__color';
 
-interface TabItemProps {
+export interface TabItemProps {
   children: React.ReactNode;
   selected?: boolean;
-  onClick: React.EventHandler<React.SyntheticEvent>;
+  setTab: Function;
+  itemValue: number;
+  currentValue: number;
 }
 export function TabItem(props: TabItemProps) {
-  const { children, selected = false, onClick } = props;
+  const { children, setTab, itemValue, currentValue } = props;
+  function handleTabChange(tabNumber: number) {
+    return (event: React.SyntheticEvent): void => {
+      event.preventDefault();
+      setTab(tabNumber);
+    };
+  }
   return (
     <>
-      <TabItem.Wrapper onClick={onClick} selected={selected}>
+      <TabItem.Wrapper onClick={handleTabChange(itemValue)} selected={currentValue === itemValue}>
         {children}
       </TabItem.Wrapper>
       <div>
-        <TabItem.Seperator selected={selected}></TabItem.Seperator>
+        <TabItem.Seperator selected={currentValue === itemValue}></TabItem.Seperator>
       </div>
     </>
   );
@@ -63,9 +71,24 @@ TabItem.Wrapper = styled.button<Pick<TabItemProps, 'selected'>>`
   }}
 `;
 
-export default function Tab(props: Pick<TabItemProps, 'children'>) {
-  const { children } = props;
-  return <Tab.Wrapper>{children}</Tab.Wrapper>;
+export interface TabProps {
+  children: Function;
+  onTabChange?: Function;
+}
+export default function Tab(props: TabProps) {
+  const [tab, setTab] = React.useState(0);
+  const { children, onTabChange } = props;
+  function changeHandler(value) {
+    setTab(value);
+    onTabChange && onTabChange(value);
+  }
+  function composeProps() {
+    return {
+      setTab: changeHandler,
+      tab,
+    };
+  }
+  return <Tab.Wrapper>{children(composeProps())}</Tab.Wrapper>;
 }
 
 Tab.Wrapper = styled.div`

--- a/src/components/ui/Table/index.tsx
+++ b/src/components/ui/Table/index.tsx
@@ -3,21 +3,28 @@ import styled from '@emotion/styled';
 import { SECONDARY_LIGHT_SMOKE, GAINS_BORO } from 'settings/__color';
 
 interface ItemProps {
-  flexValue: number;
+  flexValue?: number;
   children: React.ReactNode | string;
+  textAlign?: string;
 }
 
 export function TableItem(props: ItemProps): React.ReactElement {
-  const { children, flexValue } = props;
-  return <TableItem.Wrapper flexValue={flexValue}>{children}</TableItem.Wrapper>;
+  const { children, flexValue = 1, textAlign = 'left' } = props;
+  return (
+    <TableItem.Wrapper textAlign={textAlign} flexValue={flexValue}>
+      {children}
+    </TableItem.Wrapper>
+  );
 }
 export function TableCard({ children }: Pick<ItemProps, 'children'>): React.ReactElement {
   return <TableCard.Wrapper>{children}</TableCard.Wrapper>;
 }
 
-TableItem.Wrapper = styled.div<Pick<ItemProps, 'flexValue'>>`
+TableItem.Wrapper = styled.div<Pick<ItemProps, 'flexValue' | 'textAlign'>>`
   flex: ${props => props.flexValue};
+  text-align: ${props => props.textAlign};
   padding-left: 2%;
+  width: 100%;
 `;
 TableCard.Wrapper = styled.div`
   display: flex;


### PR DESCRIPTION
#### What does this PR achieve?
- adds settings layout to the app
- extends Tab so that it can change/select TabItems
- extends Input component to accept a placeholder text
- adds examples for TabItems that makes it respond to tab changes
- adds textAlign prop to TableItem

#### Any background context?
- none

#### Manual Testing Steps
- Run npx yarn run storybook
- You should see examples of SettingsLayout portal

#### Screenshots:
<img width="1435" alt="Screenshot 2020-03-29 at 6 44 30 PM" src="https://user-images.githubusercontent.com/38565349/77856330-4e6ad200-71ee-11ea-8ecb-913b9be63947.png">
<img width="1442" alt="Screenshot 2020-03-29 at 6 44 09 PM" src="https://user-images.githubusercontent.com/38565349/77856333-5296ef80-71ee-11ea-8565-686e68e5381d.png">

#### Relevant Trello Tickets
- [Create Settings Layout](https://trello.com/c/dtNj0L0V/100-create-setting-tab-bar)

