### PR TITLE
Prof: Add Appliance  Category page

### DIFF
--- a/src/components/containers/OrganisationPortalContainer/index.tsx
+++ b/src/components/containers/OrganisationPortalContainer/index.tsx
@@ -21,7 +21,6 @@ export default function withOrganisationPortalContainer(WrappedComponent) {
         ...props,
       };
     }
-
     /* TypeScript doesn't recognize WrappedComponent in JSX here
      * So I defaulted to using React.createElement
      */

--- a/src/components/layouts/ApplianceCategoryLayout/index.stories.tsx
+++ b/src/components/layouts/ApplianceCategoryLayout/index.stories.tsx
@@ -1,0 +1,65 @@
+import * as React from 'react';
+import ApplianceCategoryLayout from '.';
+import { number } from '@storybook/addon-knobs';
+import { action } from '@storybook/addon-actions';
+
+export default {
+  component: ApplianceCategoryLayout,
+  title: 'components/layouts/ApplianceCategoryLayout',
+};
+const handleChange = () => true;
+export const emptyStructure = () => {
+  const values = { search: '', tabSelected: 0 };
+  const applianceCategory = {
+    name: 'Generator',
+    description: 'A beautiful Genset gropuer',
+  };
+  return (
+    <ApplianceCategoryLayout
+      handleChange={handleChange}
+      values={values}
+      applianceCategory={applianceCategory}
+      handleObjectClicked={action('objectClicked')}
+      handleCreateBtnClicked={action('create New')}
+    />
+  );
+};
+
+export const layoutWithContnent = () => {
+  const applianceCategory = {
+    name: 'Generator',
+    description: `
+      Lorem ipsum dolor sit amet, consectetur adipisicing elit. Aliquid atque dolorum eum nobis obcaecati, perferendis
+        praesentium quis rerum? A culpa cum error incidunt nemo neque quaerat quas quasi quo voluptates! Eos fuga modi
+        molestiae, mollitia necessitatibus nulla quasi quod sint suscipit vitae! Eum id numquam quaerat quidem vero!
+        Alias animi aut dolores eligendi excepturi harum minima quam rem tenetur voluptatem. Aliquam distinctio ea eos
+        ex impedit quia quisquam vero voluptatum! Assumenda blanditiis commodi dicta dolores eaque fugiat ipsa laborum
+        odio rerum unde? Doloribus illo inventore officiis possimus reprehenderit similique soluta! Assumenda cum
+        cupiditate dolorum hic illo, itaque labore magnam maxime non perferendis, ratione recusandae reprehenderit ullam
+        veniam voluptatem. A ad asperiores beatae dolore doloremque ex harum ipsam magni numquam perspiciatis! Culpa
+        dicta et in minus nisi, praesentium quis ullam vero! Autem corporis earum labore magnam modi obcaecati
+        temporibus. Amet distinctio dolore non quam velit! Autem ipsam maxime optio saepe tempora! Lorem ipsum dolor sit
+        amet, consectetur adipisicing elit. Aliquid atque dolorum eum nobis obcaecati, perferendis praesentium quis
+        rerum? A culpa cum error incidunt nemo neque quaerat quas quasi quo voluptates! Eos fuga modi molestiae,
+        mollitia necessitatibus nulla quasi quod sint suscipit vitae! Eum id numquam quaerat quidem vero! Alias animi
+        aut dolores eligendi excepturi harum minima quam rem tenetur voluptatem. Aliquam distinctio ea eos ex impedit
+        quia quisquam vero voluptatum! Assumenda blanditiis commodi dicta dolores eaque fugiat ipsa laborum odio rerum
+        unde? Doloribus illo inventore officiis possimus reprehenderit similique soluta! Assumenda cum cupiditate
+        dolorum hic illo, itaque labore magnam maxime non perferendis, ratione recusandae reprehenderit ullam veniam
+        voluptatem. A ad asperiores beatae dolore doloremque ex harum ipsam magni numquam perspiciatis! Culpa dicta et
+        in minus nisi, praesentium quis ullam vero! Autem corporis earum labore magnam modi obcaecati temporibus. Amet
+        distinctio dolore non quam velit! Autem ipsam maxime optio saepe tempora!
+    `,
+  };
+
+  const values = { search: '', tabSelected: 0 };
+  return (
+    <ApplianceCategoryLayout
+      handleChange={handleChange}
+      values={values}
+      applianceCategory={applianceCategory}
+      handleObjectClicked={action('objectClicked')}
+      handleCreateBtnClicked={action('create New')}
+    />
+  );
+};

--- a/src/components/layouts/ApplianceCategoryLayout/index.tsx
+++ b/src/components/layouts/ApplianceCategoryLayout/index.tsx
@@ -1,0 +1,108 @@
+import * as React from 'react';
+import styled from '@emotion/styled';
+import TableContentParser from 'components/ui/TableContentParser';
+import Input from '../../ui/Input';
+import Button from 'components/ui/Button';
+import ReadMore from '../../ui/ReadMore';
+import { BRAND_PRIMARY } from '../../../settings/__color';
+import { fontSizes } from '../../../settings/__fonts';
+import { TableItem } from '../../ui/Table';
+import { parseText } from '../../../helpers';
+
+interface CategoryLayoutProps {
+  appliances?: Record<string, unknown>[];
+  applianceCategory: Record<string, string>;
+  values: {
+    search: string;
+  };
+  handleChange: React.EventHandler<React.SyntheticEvent>;
+  handleObjectClicked?: (type: string, obj: object) => void; //should be compulsory later
+  handleCreateBtnClicked: React.EventHandler<React.SyntheticEvent>;
+}
+
+function getApplianceItem(appliance) {
+  return (
+    <>
+      <TableItem flexValue={2}>{appliance.label}</TableItem>
+      <TableItem flexValue={10}>{appliance.description}</TableItem>
+    </>
+  );
+}
+export default function ApplianceCategoryPageLayout(props: CategoryLayoutProps) {
+  const sampleAppliances = [{ label: 'KTA 50 101' }, { label: 'KTA 70 101' }];
+  const {
+    appliances = sampleAppliances,
+    values,
+    handleChange,
+    applianceCategory,
+    handleObjectClicked,
+    handleCreateBtnClicked,
+  } = props;
+
+  const caption = {
+    0: 'Show full description',
+    1: 'Show less',
+  };
+
+  return (
+    <ApplianceCategoryPageLayout.Wrapper>
+      <ReadMore caption={caption}>{applianceCategory.description}</ReadMore>
+
+      <ApplianceCategoryPageLayout.ControlsWrapper>
+        <ApplianceCategoryPageLayout.Heading>Appliances</ApplianceCategoryPageLayout.Heading>
+        <ApplianceCategoryPageLayout.Search>
+          <Input
+            iconLabel="md-search"
+            type="text"
+            name="search"
+            title=""
+            errorFeedback={[]}
+            handleChange={handleChange}
+            placeholder="Search"
+            value={values.search}
+          />
+        </ApplianceCategoryPageLayout.Search>
+
+        <ApplianceCategoryPageLayout.NewItem>
+          <Button type="button" isLoading={false} disabled={false} handleClick={handleCreateBtnClicked}>
+            Create New
+          </Button>
+        </ApplianceCategoryPageLayout.NewItem>
+      </ApplianceCategoryPageLayout.ControlsWrapper>
+      <div>
+        <TableContentParser data={appliances}>{getApplianceItem}</TableContentParser>
+      </div>
+    </ApplianceCategoryPageLayout.Wrapper>
+  );
+}
+
+ApplianceCategoryPageLayout.Search = styled.div`
+  flex: 4;
+  padding: 0;
+  width: 100%;
+`;
+
+ApplianceCategoryPageLayout.ControlsWrapper = styled.div`
+  display: flex;
+  align-items: center;
+  > div {
+    padding: 0 2%;
+    &:first-child {
+      padding-left: 0;
+    }
+  }
+  margin-top: 4%;
+  flex: space-between;
+`;
+
+ApplianceCategoryPageLayout.NewItem = styled.div`
+  flex: 2;
+`;
+
+ApplianceCategoryPageLayout.Heading = styled.h2`
+  color: ${BRAND_PRIMARY};
+  font-size: ${fontSizes.medium};
+  flex: 7;
+`;
+
+ApplianceCategoryPageLayout.Wrapper = styled.div``;

--- a/src/components/layouts/SettingsPageLayout/index.stories.tsx
+++ b/src/components/layouts/SettingsPageLayout/index.stories.tsx
@@ -18,7 +18,7 @@ export const emptyStructure = () => {
       handleChange={handleChange}
       handleTabChange={handleTabChange}
       currentWindow={number('currentWindow', 0)}
-      handleObjectClicked={action('objectClicked')}
+      handleObjectClicked={() => action('objectClicked')}
       handleCreateBtnClicked={action('create New')}
     />
   );
@@ -119,7 +119,7 @@ export const layoutWithContnent = () => {
       applianceCategories={applianceCategories}
       parameters={parameters}
       currentWindow={number('currentWindow', 0)}
-      handleObjectClicked={action('objectClicked')}
+      handleObjectClicked={() => action('objectClicked')}
       handleCreateBtnClicked={action('create New')}
     />
   );

--- a/src/components/pages/OrganisationPortal/ApplianceCategory/AddAppliance.tsx
+++ b/src/components/pages/OrganisationPortal/ApplianceCategory/AddAppliance.tsx
@@ -1,0 +1,65 @@
+import * as React from 'react';
+import { Modal } from 'components/ui/Modal';
+import ModalCard from 'components/ui/Modal/ModalCard';
+import Form from 'components/ui/Form';
+import Input from 'components/ui/Input';
+import { pickErrors } from 'helpers';
+
+const { Fragment } = React;
+interface CreateCategoryProps {
+  handleSubmit: (trigger: string) => (values: Record<string, any>) => void;
+  hideModal: React.EventHandler<React.SyntheticEvent>;
+  apiErrors?: Record<string, unknown>;
+}
+export default function CreateCategory(props: CreateCategoryProps) {
+  const { handleSubmit, hideModal, apiErrors = {} } = props;
+  const defaultValues = {
+    label: '',
+    specs: {},
+    parameters: [],
+  };
+  return (
+    <Modal>
+      <ModalCard cardTitle="Add Appliance to CategoryName" handleToggleModal={hideModal}>
+        <Form
+          submitButtonLabel="Add Appliance"
+          handleSubmit={handleSubmit('ADD_APPLIANCE')}
+          validationSchemaKey="addAppliance"
+          defaultValues={defaultValues}
+        >
+          {({ handleChange, errors, values, handleBlur }): React.ReactNode => (
+            <Fragment>
+              <Input
+                name="name"
+                title="label"
+                autoComplete="off"
+                value={values.name}
+                handleChange={handleChange}
+                handleBlur={handleBlur}
+                errorFeedback={pickErrors(errors, apiErrors).name}
+              />
+              <Input
+                name="parameters"
+                title="Parameters"
+                autoComplete="off"
+                value={values.name}
+                handleChange={handleChange}
+                handleBlur={handleBlur}
+                errorFeedback={pickErrors(errors, apiErrors).name}
+              />
+              <Input
+                name="specs"
+                title="specs"
+                autoComplete="off"
+                value={values.name}
+                handleChange={handleChange}
+                handleBlur={handleBlur}
+                errorFeedback={pickErrors(errors, apiErrors).name}
+              />
+            </Fragment>
+          )}
+        </Form>
+      </ModalCard>
+    </Modal>
+  );
+}

--- a/src/components/pages/OrganisationPortal/ApplianceCategory/index.tsx
+++ b/src/components/pages/OrganisationPortal/ApplianceCategory/index.tsx
@@ -1,0 +1,77 @@
+import * as React from 'react';
+import styled from '@emotion/styled';
+import { OrgPortalHeading } from 'components/layouts/NavigationLayout';
+import ApplianceCategoryLayout from 'components/layouts/ApplianceCategoryLayout';
+import { OrgPortalProps } from 'components/pages/OrganisationPortal';
+import AddAppliance from './AddAppliance';
+import { connect } from 'react-redux';
+import withOrganisationPortalContainer from 'components/containers/OrganisationPortalContainer';
+
+interface CategoryProps extends OrgPortalProps {
+  handleSubmit: (trigger: string) => (values: Record<string, any>) => void;
+}
+export function ApplianceCategory(props: CategoryProps) {
+  const { handleSubmit } = props;
+  const [showModal, setShowModal] = React.useState(false);
+  function toggleModal(show: boolean): React.EventHandler<React.SyntheticEvent> {
+    return function(e) {
+      e.preventDefault();
+      setShowModal(show);
+    };
+  }
+
+  function handleChange() {
+    console.log('Wwould add operation here');
+  }
+  const sampleApplianceCategory = {
+    name: 'Generator',
+    description: `
+      Lorem ipsum dolor sit amet, consectetur adipisicing elit. Aliquid atque dolorum eum nobis obcaecati, perferendis
+        praesentium quis rerum? A culpa cum error incidunt nemo neque quaerat quas quasi quo voluptates! Eos fuga modi
+        molestiae, mollitia necessitatibus nulla quasi quod sint suscipit vitae! Eum id numquam quaerat quidem vero!
+        Alias animi aut dolores eligendi excepturi harum minima quam rem tenetur voluptatem. Aliquam distinctio ea eos
+        ex impedit quia quisquam vero voluptatum! Assumenda blanditiis commodi dicta dolores eaque fugiat ipsa laborum
+        odio rerum unde? Doloribus illo inventore officiis possimus reprehenderit similique soluta! Assumenda cum
+        cupiditate dolorum hic illo, itaque labore magnam maxime non perferendis, ratione recusandae reprehenderit ullam
+        veniam voluptatem. A ad asperiores beatae dolore doloremque ex harum ipsam magni numquam perspiciatis! Culpa
+        dicta et in minus nisi, praesentium quis ullam vero! Autem corporis earum labore magnam modi obcaecati
+        temporibus. Amet distinctio dolore non quam velit! Autem ipsam maxime optio saepe tempora! Lorem ipsum dolor sit
+        amet, consectetur adipisicing elit. Aliquid atque dolorum eum nobis obcaecati, perferendis praesentium quis
+        rerum? A culpa cum error incidunt nemo neque quaerat quas quasi quo voluptates! Eos fuga modi molestiae,
+        mollitia necessitatibus nulla quasi quod sint suscipit vitae! Eum id numquam quaerat quidem vero! Alias animi
+        aut dolores eligendi excepturi harum minima quam rem tenetur voluptatem. Aliquam distinctio ea eos ex impedit
+        quia quisquam vero voluptatum! Assumenda blanditiis commodi dicta dolores eaque fugiat ipsa laborum odio rerum
+        unde? Doloribus illo inventore officiis possimus reprehenderit similique soluta! Assumenda cum cupiditate
+        dolorum hic illo, itaque labore magnam maxime non perferendis, ratione recusandae reprehenderit ullam veniam
+        voluptatem. A ad asperiores beatae dolore doloremque ex harum ipsam magni numquam perspiciatis! Culpa dicta et
+        in minus nisi, praesentium quis ullam vero! Autem corporis earum labore magnam modi obcaecati temporibus. Amet
+        distinctio dolore non quam velit! Autem ipsam maxime optio saepe tempora!
+    `,
+  };
+  const values = {
+    search: '',
+  };
+  return (
+    <div>
+      <OrgPortalHeading>Generator</OrgPortalHeading>
+      <ApplianceCategoryLayout
+        handleCreateBtnClicked={toggleModal(true)}
+        applianceCategory={sampleApplianceCategory}
+        values={values}
+        handleChange={handleChange}
+      />
+      {showModal && (
+        <AddAppliance
+          hideModal={toggleModal(false)}
+          handleSubmit={handleSubmit}
+          // apiErrors={createApplianceCategory.errors}
+        />
+      )}
+    </div>
+  );
+}
+ApplianceCategory.Wraapper = styled.div`
+  // padding-right: 10%;
+`;
+
+export default connect(null, null)(withOrganisationPortalContainer(ApplianceCategory));

--- a/src/components/pages/OrganisationPortal/Settings/index.tsx
+++ b/src/components/pages/OrganisationPortal/Settings/index.tsx
@@ -7,6 +7,7 @@ import { SettingObjectType, CreateObjectType } from 'store/reducers/setting';
 import { OrgPortalProps } from '../index';
 import withOrganisationPortalContainer from 'components/containers/OrganisationPortalContainer';
 import { OrgPortalHeading } from 'components/layouts/NavigationLayout';
+import { moveToNextPage } from 'store/actions/navigation';
 
 interface SettingsProps extends OrgPortalProps {
   applianceCategory: SettingObjectType;
@@ -31,6 +32,7 @@ function Settings(props: SettingsProps) {
     justCreated,
     match: { params },
     handleSubmit,
+    moveToNextPage,
   } = props;
   const defaultValues = {
     search: '',
@@ -65,12 +67,14 @@ function Settings(props: SettingsProps) {
     setValues(prevState => ({ ...prevState, [name]: value }));
   }
 
-  function handleObjectClicked(type: string, obj: object) {
+  function handleObjectClicked(type: string) {
     //  TODO: This is where we ought to handle click events of the table rows
     //        The type here would be one of units | paramters | applianceCategory
     //        We are supposed to either move to another page or perform some other operation here
-    console.log(type);
-    console.log(obj);
+    //        You can log this to be sure
+    return function(obj: Record<string, string>) {
+      moveToNextPage({ nextPageRoute: `appliance-category/${obj.id}` });
+    };
   }
 
   // TODO: The image here is supposed to the retrieved from organisation data in the store
@@ -127,6 +131,7 @@ const mapDispatchToProps = dispatch => ({
   fetchUnits: (payload): string => dispatch(fetchUnits(payload)),
   fetchApplianceCategory: (payload): void => dispatch(fetchApplianceCategory(payload)),
   callCreateApplianceCategory: (payload): void => dispatch(createApplianceCategory(payload)),
+  moveToNextPage: (payload): void => dispatch(moveToNextPage(payload)),
 });
 
 export default connect(mapStateToProps, mapDispatchToProps)(withOrganisationPortalContainer(Settings));

--- a/src/components/pages/OrganisationPortal/index.tsx
+++ b/src/components/pages/OrganisationPortal/index.tsx
@@ -43,6 +43,11 @@ function getOrganisationRoutes(path: string): RouteProps[] {
       component: withSuspense({ page: 'OrganisationPortal/Logs' }),
       exact: true,
     },
+    {
+      path: `${path}/appliance-category/:categoryId`,
+      component: withSuspense({ page: 'OrganisationPortal/ApplianceCategory' }),
+      exact: true,
+    },
   ];
 }
 

--- a/src/components/ui/ReadMore/index.stories.tsx
+++ b/src/components/ui/ReadMore/index.stories.tsx
@@ -1,0 +1,30 @@
+import React from 'react';
+import ReadMore from '.';
+export default {
+  component: ReadMore,
+  title: 'components/ui/ReadMore',
+};
+
+export const readMore = (): React.ReactElement => (
+  <ReadMore>
+    Lorem ipsum dolor sit amet, consectetur adipisicing elit. Aliquid atque dolorum eum nobis obcaecati, perferendis
+    praesentium quis rerum? A culpa cum error incidunt nemo neque quaerat quas quasi quo voluptates! Eos fuga modi
+    molestiae, mollitia necessitatibus nulla quasi quod sint suscipit vitae! Eum id numquam quaerat quidem vero! Alias
+    animi aut dolores eligendi excepturi harum minima quam rem tenetur voluptatem. Aliquam distinctio ea eos ex impedit
+    quia quisquam vero voluptatum! Assumenda blanditiis commodi dicta dolores eaque fugiat ipsa laborum odio rerum unde?
+    Doloribus illo inventore officiis possimus reprehenderit similique soluta! Assumenda cum cupiditate dolorum hic
+    illo, itaque labore magnam maxime non perferendis, ratione recusandae reprehenderit ullam veniam voluptatem. A ad
+    asperiores beatae dolore doloremque ex harum ipsam magni numquam perspiciatis! Culpa dicta et in minus nisi,
+    praesentium quis ullam vero! Autem corporis earum labore magnam modi obcaecati temporibus. Amet distinctio dolore
+    non quam velit! Autem ipsam maxime optio saepe tempora! Lorem ipsum dolor sit amet, consectetur adipisicing elit.
+    Aliquid atque dolorum eum nobis obcaecati, perferendis praesentium quis rerum? A culpa cum error incidunt nemo neque
+    quaerat quas quasi quo voluptates! Eos fuga modi molestiae, mollitia necessitatibus nulla quasi quod sint suscipit
+    vitae! Eum id numquam quaerat quidem vero! Alias animi aut dolores eligendi excepturi harum minima quam rem tenetur
+    voluptatem. Aliquam distinctio ea eos ex impedit quia quisquam vero voluptatum! Assumenda blanditiis commodi dicta
+    dolores eaque fugiat ipsa laborum odio rerum unde? Doloribus illo inventore officiis possimus reprehenderit
+    similique soluta! Assumenda cum cupiditate dolorum hic illo, itaque labore magnam maxime non perferendis, ratione
+    recusandae reprehenderit ullam veniam voluptatem. A ad asperiores beatae dolore doloremque ex harum ipsam magni
+    numquam perspiciatis! Culpa dicta et in minus nisi, praesentium quis ullam vero! Autem corporis earum labore magnam
+    modi obcaecati temporibus. Amet distinctio dolore non quam velit! Autem ipsam maxime optio saepe tempora!
+  </ReadMore>
+);

--- a/src/components/ui/ReadMore/index.tsx
+++ b/src/components/ui/ReadMore/index.tsx
@@ -1,0 +1,61 @@
+import * as React from 'react';
+import styled from '@emotion/styled';
+import { BRAND_PRIMARY } from 'settings/__color';
+import { fontSizes } from '../../../settings/__fonts';
+
+interface ReadMoreDivsProps {
+  showMore: boolean;
+}
+
+interface ReadMoreProps {
+  children: React.ReactNode;
+  caption?: {
+    0: string;
+    1: string;
+  };
+}
+
+export default function ReadMore(props: ReadMoreProps) {
+  const defaultCaption = {
+    0: 'Show More',
+    1: 'Show Less',
+  };
+  const { children, caption = defaultCaption } = props;
+  const [showMore, setShowMore] = React.useState(false);
+  function handleClick() {
+    setShowMore(!showMore);
+  }
+  return (
+    <div>
+      <ReadMore.Wrapper showMore={showMore}>{children}</ReadMore.Wrapper>
+      <ReadMore.ShowMore onClick={handleClick}>{caption[+showMore]}</ReadMore.ShowMore>
+    </div>
+  );
+}
+
+ReadMore.ShowMore = styled.div`
+  text-align: center;
+  color: ${BRAND_PRIMARY};
+  cursor: pointer;
+  font-weight: bold;
+  font-size: ${fontSizes.normal};
+  text-transform: uppercase;
+  &:hover {
+    text-decoration: underline;
+  }
+`;
+
+ReadMore.Wrapper = styled.p<ReadMoreDivsProps>`
+  line-height: 1.58;
+  letter-spacing: -0.004em;
+  word-break: break-word;
+  max-height: 4.75em;
+  overflow-y: hidden;
+  transition: max-height 0.8s linear;
+  text-align: justify;
+  ${props =>
+    props.showMore &&
+    `
+   max-height: 56.25em;
+  `}
+`;

--- a/src/components/ui/TableContentParser/index.tsx
+++ b/src/components/ui/TableContentParser/index.tsx
@@ -1,0 +1,37 @@
+import * as React from 'react';
+import Table, { TableCard, TableItem } from 'components/ui/Table';
+
+interface TableContentParserProps {
+  data: object[];
+  children: (obj: Record<string, any>) => React.ReactNode;
+  onClick?: (obj: object) => void;
+}
+
+export default function TableContentParser(props: TableContentParserProps) {
+  const { data, onClick, children } = props;
+  if (data.length === 0) {
+    return (
+      <Table>
+        <TableCard>
+          <TableItem textAlign="center">No Results was found</TableItem>
+        </TableCard>
+      </Table>
+    );
+  }
+  function onClickHandler(obj): React.EventHandler<React.SyntheticEvent> {
+    return function(e) {
+      e.preventDefault();
+      onClick && onClick(obj);
+    };
+  }
+
+  return (
+    <Table>
+      {data.map((obj, index) => (
+        <TableCard key={index} onClick={onClickHandler(obj)}>
+          {children(obj)}
+        </TableCard>
+      ))}
+    </Table>
+  );
+}

--- a/src/helpers/index.ts
+++ b/src/helpers/index.ts
@@ -7,3 +7,10 @@ export function pickErrors(formErrors, apiError) {
   }
   return returnedErrors || {};
 }
+
+export function parseText(text: string, limit?: number) {
+  if (limit && text.length > limit) {
+    return text.substring(0, limit) + '...';
+  }
+  return text;
+}


### PR DESCRIPTION
#### What does this PR achieve?
- adds ApplianceCategory layout
- uses mock data to set up the appliance category page
- adds storybook for layout
- adds a ReadMore component 

#### Any background context?
- this only adds the page with mock data

#### Manual Testing Steps
- Navigate to /organisation/:orgId/appliance-category/:cat-id

#### Screenshots:

![Screen Recording 2020-04-07 at 10 52 35 PM](https://user-images.githubusercontent.com/38565349/78724101-98596380-7924-11ea-9dcc-b77fba938065.gif)

#### Relevant Trello Tickets
- [Add Appliance Category](https://trello.com/c/sXxBFdmX/113-add-appliance-category-page)

